### PR TITLE
Fixed crash while loading ResultCell

### DIFF
--- a/Xniffer.podspec
+++ b/Xniffer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Xniffer"
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.summary          = "A swift network profiler built on top URLSession."
   s.homepage         = "https://github.com/xmartlabs/Xniffer"
   s.license          = { type: 'MIT', file: 'LICENSE' }
@@ -9,9 +9,6 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/xmartlabs'
   s.ios.deployment_target = '9.0'
   s.requires_arc = true
-  s.ios.source_files = 'Sources/**/*.{swift}'
-  s.resource_bundles = {
-    'Xniffer' => ['Sources/**/*.xib']
-  }
+  s.source_files = ['Sources/**/*.xib', 'Sources/**/*.{swift}']
   s.ios.frameworks = 'UIKit', 'Foundation'
 end


### PR DESCRIPTION
Fixes #3

Changes proposed in this request:
* Removed usage of `resource_bundles` on the podspec. Now all file path are set on `source_files`. This fixes the issue of the ResultCell's xib not being found.


