### PR TITLE
Updated properties access level.

### DIFF
--- a/Sources/Core/URLRequest+Xniffer.swift
+++ b/Sources/Core/URLRequest+Xniffer.swift
@@ -28,7 +28,7 @@ import Foundation
 
 public extension XnifferResult {
 
-    func cURLRepresentation() -> String {
+    public func cURLRepresentation() -> String {
         var components = ["$ curl -i"]
         
         guard let url = request.url else {

--- a/Sources/Core/Xniffer.swift
+++ b/Sources/Core/Xniffer.swift
@@ -80,11 +80,11 @@ public protocol XnifferDelegate: class {
 
 public final class Xniffer {
 
-    weak var delegate: XnifferDelegate?
+    public var delegate: XnifferDelegate?
     private var requests = [RequestWrapper]()
     private static var profilerWindow: XnifferWindow?
 
-    static let shared = Xniffer()
+    public static let shared = Xniffer()
 
     private init () {}
 

--- a/Xniffer.podspec
+++ b/Xniffer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Xniffer"
-  s.version          = "1.0.2"
+  s.version          = "1.0.3"
   s.summary          = "A swift network profiler built on top URLSession."
   s.homepage         = "https://github.com/xmartlabs/Xniffer"
   s.license          = { type: 'MIT', file: 'LICENSE' }


### PR DESCRIPTION
Updated access levels to Xniffer properties to enable setting the delegate from outside of the class.
Now you can set a custom delegate using the callback provided in the `.custom` mode as initially intended.

Fixes #issue(s) .
#5 



